### PR TITLE
fix: Resolves the error exception when the national ID is less than 1…

### DIFF
--- a/src/NaturalizationRecord.php
+++ b/src/NaturalizationRecord.php
@@ -78,7 +78,10 @@ final class NaturalizationRecord
 
         $natIdNum = $this->natIdNum();
         $isPatternValid = $this->validatePattern($natIdNum);
-        $isAlgorithmValid = $this->validateAlgorithm($natIdNum) || $this->validateUsingAlternativeAlgorithm($natIdNum);
+
+        if ($isPatternValid) {
+            $isAlgorithmValid = $this->validateAlgorithm($natIdNum) || $this->validateUsingAlternativeAlgorithm($natIdNum);
+        }
 
         if (! ($isPatternValid && $isAlgorithmValid)) {
             $this->throwValidationException('The given national identification number is invalid.');

--- a/tests/NaturalizationRecordTest.php
+++ b/tests/NaturalizationRecordTest.php
@@ -56,4 +56,16 @@ class NaturalizationRecordTest extends TestCase
         $this->assertSame('ATATÜRK', $naturalizationRecord->lastName());
         $this->assertSame($birthYear, $naturalizationRecord->birthYear());
     }
+
+    public function test_it_must_be_11_characters(): void
+    {
+        $this->expectException(InvalidTurkishNationalIdentificationNumberException::class);
+
+        new NaturalizationRecord(
+            '',
+            'Gazi Mustafa Kemal',
+            'Atatürk',
+            '1881'
+        );
+    }
 }


### PR DESCRIPTION
T.C. Numarası 11 karakterden az olduğu durumlarda **validateAlgorithm** ve **validateUsingAlternativeAlgorithm** methodlarından error exception alınmaktadır. Bu commit bu hatayı giderir.